### PR TITLE
the 'end' callback of previous countdown timers are overwritten due t…

### DIFF
--- a/circular-countdown.js
+++ b/circular-countdown.js
@@ -27,7 +27,7 @@
 
     function CircularCountDown(data, element) {
         this.element = element;
-        this.data = jQuery.extend(true, defaultOptions, data);
+        this.data = jQuery.extend(true, {}, defaultOptions, data);
         this.init();
     }
 


### PR DESCRIPTION
the 'end' callback of previous countdown timers are overwritten due to defaultOptions being used as the target data instead of a new object


the fix is to use a new object when calling `jQuery.extend`